### PR TITLE
Setup EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,3 +35,14 @@ end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+
+## PPL Sources
+##############
+[*.ppl]
+indent_style = space
+indent_size = 4
+end_of_line = unset
+charset = utf-8
+trim_trailing_whitespace = unset
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,37 @@
+root = true
+
+
+## Repository Configurations
+############################
+[.{git*,editorconfig,*.yml}]
+end_of_line = lf
+indent_style = space
+indent_size = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[.gitmodules]
+indent_style = tab
+
+
+## Shell Scripts
+################
+[*.sh]
+end_of_line = lf
+indent_style = tab
+indent_size = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Batch Scripts
+################
+[*.bat]
+indent_style = tab
+indent_size = unset
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,23 @@
 # Default behavior
 * text=auto
 
-# Unix script files use LF
-*.sh text eol=lf
+
+## Shell Scripts
+################
+*.bat text eol=crlf
+*.sh  text eol=lf
+
+## Repository Configuration
+###########################
+.editorconfig  text eol=lf
+.gitlab-ci.yml text eol=lf
+.travis.yml    text eol=lf
+.gitattributes text eol=lf
+.gitconfig     text eol=lf
+.gitignore     text eol=lf
+.gitmodules    text eol=lf
+
+## GitHub Linguist Settings
+###########################
+*.ppl linguist-language=PPL
+

--- a/work/src/PPL/dev/pml/converter/PAIOM_commands/se_PML_PAIOM_commands.ppl
+++ b/work/src/PPL/dev/pml/converter/PAIOM_commands/se_PML_PAIOM_commands.ppl
@@ -3,9 +3,9 @@
 
 service PML_PAIOM_commands
 
-	att commands PAIOM_commands
-		default
-			const r = PAIOM_commands_builder.create
+    att commands PAIOM_commands
+        default
+            const r = PAIOM_commands_builder.create
 
             r.add_command ( se_PML_convert_command.command )
             r.add_command ( se_PML_help_command.command )
@@ -17,7 +17,7 @@ service PML_PAIOM_commands
             // r.add_command ( se_PML_start_GUI_command.command )
             r.add_command ( se_PML_create_reference_manual_command.command )
 
-			return r.make_immutable
-		.
-	.
+            return r.make_immutable
+        .
+    .
 .

--- a/work/src/PPL/dev/pml/converter/PAIOM_commands/se_PML_convert_command.ppl
+++ b/work/src/PPL/dev/pml/converter/PAIOM_commands/se_PML_convert_command.ppl
@@ -112,9 +112,9 @@ By default this parameter is set to 'no'.'''
             examples = '''pmlc convert -f input/index.pml
 pmlc convert --input_file input/index.pml --output_directory output/HTML --resources_directory images''' ) )
 
-	function execute ( input any_type_parameters or null ) -> file or anticipated_error
+    function execute ( input any_type_parameters or null ) -> file or anticipated_error
 
-        try	
+        try    
             assert i_input is not null
     
             const PML_input_path = i_input.get_value<absolute_or_relative_file_path> ( a_input_file_parameter.standard_id )

--- a/work/src/PPL/dev/pml/converter/PAIOM_commands/se_PML_create_reference_manual_command.ppl
+++ b/work/src/PPL/dev/pml/converter/PAIOM_commands/se_PML_create_reference_manual_command.ppl
@@ -41,15 +41,15 @@ The temporary directory can manually be deleted after the PML Reference Manual h
             description = "This command creates the PML reference manual."
             examples = null ) )
 
-	function execute ( input any_type_parameters or null ) -> string or anticipated_error
-	
-	    assert i_input is not null
+    function execute ( input any_type_parameters or null ) -> string or anticipated_error
+    
+        assert i_input is not null
 
-	    const temp_directory_path = i_input.get_value<absolute_or_relative_directory_path> (
-	        a_temp_directory_parameter.standard_id )
-	    const output_directory_path = i_input.get_value<absolute_or_relative_directory_path> (
-	        a_output_directory_parameter.standard_id )
+        const temp_directory_path = i_input.get_value<absolute_or_relative_directory_path> (
+            a_temp_directory_parameter.standard_id )
+        const output_directory_path = i_input.get_value<absolute_or_relative_directory_path> (
+            a_output_directory_parameter.standard_id )
 
-	    return se_PML_reference_manual.create_manual_for_path ( temp_directory_path, output_directory_path )
+        return se_PML_reference_manual.create_manual_for_path ( temp_directory_path, output_directory_path )
     .
 .

--- a/work/src/PPL/dev/pml/converter/PAIOM_commands/se_PML_tag_info_command.ppl
+++ b/work/src/PPL/dev/pml/converter/PAIOM_commands/se_PML_tag_info_command.ppl
@@ -22,9 +22,9 @@ service PML_tag_info_command
             examples = null ) )
 
 
-	function execute ( input any_type_parameters or null ) -> string
-	
-	    assert i_input is not null
+    function execute ( input any_type_parameters or null ) -> string
+    
+        assert i_input is not null
 
         const tag = i_input.require_value<string or null> ( "tag" )
 
@@ -54,7 +54,7 @@ The following tags exist: {{se_PML_formal_node_registry.sorted_any_tag_list.to_l
         .
     .
 
-	functions access:private
+    functions access:private
 
         function formal_nodes_summary_info -> string
     

--- a/work/src/PPL/dev/pml/converter/reader/analyzer/node_creators/block_node/source_code/fa_PML_insert_source_code_node_creator.ppl
+++ b/work/src/PPL/dev/pml/converter/reader/analyzer/node_creators/block_node/source_code/fa_PML_insert_source_code_node_creator.ppl
@@ -12,9 +12,9 @@ factory PML_insert_source_code_node_creator type:PML_node_creator<PML_insert_sou
             const title = title )
 
         const file_path = attributes.require_value<absolute_or_relative_file_path> ( se_PML_attribute_ids.file )
-		const file = file.create_for_absolute_or_relative_path_in_working_directory ( file_path )
-		const code = define_code ( file, i_node_AST, attributes, i_context ) on_error: return_error
-		
+        const file = file.create_for_absolute_or_relative_path_in_working_directory ( file_path )
+        const code = define_code ( file, i_node_AST, attributes, i_context ) on_error: return_error
+        
         const language = attributes.require_value<string> (
             se_PML_source_code_formal_node.language_parameter.standard_id.value )
 
@@ -23,8 +23,8 @@ factory PML_insert_source_code_node_creator type:PML_node_creator<PML_insert_sou
 
         const HTML_attributes = i_context.get_HTML_attributes ( i_node_AST )
 
-		return PML_insert_source_code_node.create (
-		    node_id, title, file, code, language, use_highlighter, HTML_attributes )
+        return PML_insert_source_code_node.create (
+            node_id, title, file, code, language, use_highlighter, HTML_attributes )
     .
     
     functions access:private

--- a/work/src/PPL/dev/pml/converter/reader/parser/fa_PML_parser.ppl
+++ b/work/src/PPL/dev/pml/converter/reader/parser/fa_PML_parser.ppl
@@ -4,8 +4,8 @@
 factory PML_parser
 
     attributes access:private
-    	
-    	variable att tokenizer PML_tokenizer default: PML_tokenizer.create_for_code ( PML_code = "dummy" )
+        
+        variable att tokenizer PML_tokenizer default: PML_tokenizer.create_for_code ( PML_code = "dummy" )
     .
 
     function try_parse

--- a/work/src/PPL/dev/pml/converter/reader/tokenizer/config/fa_PML_tokenizer_config.ppl
+++ b/work/src/PPL/dev/pml/converter/reader/tokenizer/config/fa_PML_tokenizer_config.ppl
@@ -3,8 +3,8 @@ factory PML_tokenizer_config
     creator create kind:in_all
 
     creator create_customized -> PML_tokenizer_config
-		in node_start_symbol character
-		in node_end_symbol character
+        in node_start_symbol character
+        in node_end_symbol character
 
         this.node_start_symbol = i_node_start_symbol
         this.node_end_symbol = i_node_end_symbol

--- a/work/src/PPL/dev/pml/converter/reader/tokenizer/single_resource/fa_single_resource_PML_tokenizer.ppl
+++ b/work/src/PPL/dev/pml/converter/reader/tokenizer/single_resource/fa_single_resource_PML_tokenizer.ppl
@@ -4,8 +4,8 @@
 factory single_resource_PML_tokenizer
 
     attributes access:private
-    	
-    	text_scanner text_scanner_with_line_column
+        
+        text_scanner text_scanner_with_line_column
         resource non_error or null default:null
     .
 
@@ -36,16 +36,16 @@ factory single_resource_PML_tokenizer
         consume_node_end_symbol = skip_character ( a_config.node_end_symbol )
 
         consume_node_name
-		
-		    const position = current_position
-			const value = consume_regex ( a_config.node_tag ) on_null: return null
+        
+            const position = current_position
+            const value = consume_regex ( a_config.node_tag ) on_null: return null
             return PML_token.create ( value, position )
-		.
-		
-		skip_one_space_after_node_name
-		
-		    if skip_character ( ' ' ) then
-		        return
+        .
+        
+        skip_one_space_after_node_name
+        
+            if skip_character ( ' ' ) then
+                return
             .
             skip_character ( '\t' )
         .
@@ -94,7 +94,7 @@ factory single_resource_PML_tokenizer
             const leading_text = consume_all_to_regex_excluding ( regex )
             if leading_text is null then
                 if not a_text_scanner.is_at_regex ( regex ) then
-    				return create_error_at_current_position ( """Content for '{{i_tag}}' must be terminated on a subsequent line with '{{i_tag}}{{a_config.node_end_symbol}}'.""" )
+                    return create_error_at_current_position ( """Content for '{{i_tag}}' must be terminated on a subsequent line with '{{i_tag}}{{a_config.node_end_symbol}}'.""" )
                 .
             .
             

--- a/work/src/PPL/dev/pml/converter/reader/tokenizer/token/ty_PML_token.ppl
+++ b/work/src/PPL/dev/pml/converter/reader/tokenizer/token/ty_PML_token.ppl
@@ -4,7 +4,7 @@
 type PML_token
 
     attributes
-     	value string
-     	position text_position
+        value string
+        position text_position
     .
 .

--- a/work/src/PPL/dev/pml/converter/se_CLI_start.ppl
+++ b/work/src/PPL/dev/pml/converter/se_CLI_start.ppl
@@ -33,16 +33,16 @@ examples:
 '''
     .
     
-	function start
-	
-	    const arguments = se_OS_process.command_line_arguments
-	    if arguments is null then
-		    OS.err.write_line ( a_usage_text )
+    function start
+    
+        const arguments = se_OS_process.command_line_arguments
+        if arguments is null then
+            OS.err.write_line ( a_usage_text )
             OS.err.write_line ( "Type 'pmlc help' for more information." )
 
             se_OS_process.exit_with_error
-		.
-		assert arguments is not null
+        .
+        assert arguments is not null
 
         execute_command_line_arguments ( arguments ) (
             const result = result
@@ -62,9 +62,9 @@ examples:
                     se_OS_process.exit_with_success
                 .
         .
-	.
+    .
 
-	functions access:private
+    functions access:private
 
         function execute_command_line_arguments
             in arguments indexed_list<string or null>

--- a/work/src/PPL/dev/pml/converter/se_PML_to_HTML_Converter.ppl
+++ b/work/src/PPL/dev/pml/converter/se_PML_to_HTML_Converter.ppl
@@ -118,10 +118,10 @@ service PML_to_HTML_Converter
             .
 
             return se_file_copier.try_copy_directory_content (
-		        source = resources_directory
-		        destination = output_directory
-		        file_overwrite_policy = file_copy_overwrite_policy.always_overwrite
-		        include_child_directories = yes )
+                source = resources_directory
+                destination = output_directory
+                file_overwrite_policy = file_copy_overwrite_policy.always_overwrite
+                include_child_directories = yes )
         .
     .
 .

--- a/work/src/PPL/dev/pml/converter/se_start.ppl
+++ b/work/src/PPL/dev/pml/converter/se_start.ppl
@@ -3,7 +3,7 @@
 
 service start
 
-	function start
+    function start
 
         if se_OS_process.command_line_arguments is not null then
             se_CLI_start.start
@@ -23,20 +23,20 @@ service start
                 },
                 exit_system_on_window_close = yes )
         .
-	.
-	
-	functions access:private
-	    
-	    function handle_success_result ( HTML_file file )
-	        
-	        if se_OS_config.OS_is_Windows then
-	            handle_success_result_on_Windows ( HTML_file )
+    .
+    
+    functions access:private
+        
+        function handle_success_result ( HTML_file file )
+            
+            if se_OS_config.OS_is_Windows then
+                handle_success_result_on_Windows ( HTML_file )
             else
-	            handle_success_result_on_non_Windows ( HTML_file )
+                handle_success_result_on_non_Windows ( HTML_file )
             .
         .
-	    
-	    function handle_success_result_on_Windows ( HTML_file file )
+        
+        function handle_success_result_on_Windows ( HTML_file file )
 
             const question = """The following file has been created:
 {{HTML_file.to_string}}
@@ -54,17 +54,17 @@ Do you want to open it in your default browser?"""
                     .
                 .
             .
-	    .
+        .
 
         // se_desktop_utilities.open_file_in_default_browser freezes the application on Linux Mint and Fedora (2020-06-10)    
-	    function handle_success_result_on_non_Windows ( HTML_file file )
+        function handle_success_result_on_non_Windows ( HTML_file file )
 
             const info = """The following file has been created:
 {{HTML_file.to_string}}"""
             se_GUI_dialogs.show_info_and_continue ( title = "Success", info )
-	    .
-	    
-	    function handle_error_result ( error anticipated_error )
+        .
+        
+        function handle_error_result ( error anticipated_error )
 
             case type of error
                 when PML_code_error PML_code_error then
@@ -75,5 +75,5 @@ Do you want to open it in your default browser?"""
                     se_GUI_dialogs.show_error_and_wait ( error = error.info )
             .
         .
-	.
+    .
 .

--- a/work/src/PPL/dev/pml/converter/utilities/document_writer/fa_PML_document_writer.ppl
+++ b/work/src/PPL/dev/pml/converter/utilities/document_writer/fa_PML_document_writer.ppl
@@ -6,9 +6,9 @@ factory PML_document_writer
     attributes access:private
         
         t_writer throwing_string_writer_wrapper
-    	
-    	current_indent mutable_string default:mutable_string.create
-    	single_indent string default: "    "
+        
+        current_indent mutable_string default:mutable_string.create
+        single_indent string default: "    "
     .
 
     // TD escape

--- a/work/src/PPL/dev/pml/converter/utilities/reference_manual/se_PML_reference_manual.ppl
+++ b/work/src/PPL/dev/pml/converter/utilities/reference_manual/se_PML_reference_manual.ppl
@@ -19,7 +19,7 @@ service PML_reference_manual
 
         return create_manual ( temp_directory, output_directory )
     .
-		
+        
     function create_manual -> string or anticipated_error
         in temp_directory directory
         in output_directory directory

--- a/work/src/PPL/dev/pml/converter/writer/HTML/context/fa_PML_HTML_writer_context.ppl
+++ b/work/src/PPL/dev/pml/converter/writer/HTML/context/fa_PML_HTML_writer_context.ppl
@@ -3,12 +3,12 @@
 
 factory PML_HTML_writer_context
 
-	attributes access:private
-    	current_indent mutable_string default:mutable_string.create
-    	single_indent string default: "    "
+    attributes access:private
+        current_indent mutable_string default:mutable_string.create
+        single_indent string default: "    "
     .
 
-	functions
+    functions
         
         // basics
     

--- a/work/src/PPL/dev/pml/converter/writer/HTML/context/ty_PML_HTML_writer_context.ppl
+++ b/work/src/PPL/dev/pml/converter/writer/HTML/context/ty_PML_HTML_writer_context.ppl
@@ -3,9 +3,9 @@
 
 type PML_HTML_writer_context
 
-	att writer string_writer
+    att writer string_writer
 
-	functions
+    functions
 
         // basics
     

--- a/work/src/PPL/dev/pml/converter/writer/HTML/node/block/monospace/fa_PML_monospace_node_HTML_writer.ppl
+++ b/work/src/PPL/dev/pml/converter/writer/HTML/node/block/monospace/fa_PML_monospace_node_HTML_writer.ppl
@@ -9,7 +9,7 @@ factory PML_monospace_node_HTML_writer type:PML_node_HTML_writer<PML_monospace_n
             i_node,
             HTML_tag_name = "pre"
             CSS_class_name = "pml-monospace"
-			append_new_line_for_tag = no
+            append_new_line_for_tag = no
             i_config )
     .
     

--- a/work/src/PPL/dev/pml/converter/writer/HTML/node/block/paragraph/fa_PML_paragraph_node_HTML_writer.ppl
+++ b/work/src/PPL/dev/pml/converter/writer/HTML/node/block/paragraph/fa_PML_paragraph_node_HTML_writer.ppl
@@ -9,7 +9,7 @@ factory PML_paragraph_node_HTML_writer type:PML_node_HTML_writer<PML_paragraph_n
             i_node,
             HTML_tag_name = "p"
             CSS_class_name = "pml-paragraph"
-			append_new_line_for_tag = no
+            append_new_line_for_tag = no
             i_config )
     .
     


### PR DESCRIPTION
Setup EditorConfig

Add [`.editorconfig` rules](https://editorconfig.org "Visit EditorConfig website") to enforce consistent code styles conventions across different editors for the following files types:

- Repository settings
- Shell scripts (*.sh)
- Batch scripts (*.bat)

Update `.gitattributes` accordingly, and add a GitHub Linguist rules to associate the `*.ppl` extension with the PPL language, for better repo statistics.

